### PR TITLE
Uhrzeit auf 19:30 vorbelegen

### DIFF
--- a/news/includes/editEvent.php
+++ b/news/includes/editEvent.php
@@ -19,6 +19,7 @@ if($id == 'new') {
         'DATE'          => date("Y-m-d H:i:s"),
         'AUTHOR'        => $userId,
         'MODE'          => 'new',
+        'DUE_DATE'      => date("Y-m-d 19:30:00"),
     ));
     
 } else {


### PR DESCRIPTION
Die meisten Termine finden um 19:30 Uhr statt. Daher ist eine Vorbelegung dieser Zeit sinnvoller als Mitternacht.